### PR TITLE
feat(subgraph): add WeeklyTokenMetric entity for weekly token analytics

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -231,6 +231,23 @@ type DailyTokenMetric @entity(immutable: false) {
   totalLocked: BigInt!
 }
 
+type WeeklyTokenMetric @entity(immutable: false) {
+  id: Bytes! # token address + week timestamp
+  token: Token!
+  timestamp: BigInt! # Start of week (Sunday 00:00 UTC)
+  week: BigInt! # Week number
+  # Token-specific volume
+  volume: BigInt!
+  deposit: BigInt!
+  withdrawal: BigInt!
+  settledAmount: BigInt! # Delta for this week
+  commissionPaid: BigInt!
+
+  # Token utilization
+  activeRailsCount: BigInt!
+  uniqueHolders: BigInt!
+}
+
 type DailyOperatorMetric @entity(immutable: false) {
   id: Bytes! # operator address + timestamp
   operator: Operator!

--- a/subgraph/src/utils/metrics/collectors.ts
+++ b/subgraph/src/utils/metrics/collectors.ts
@@ -117,6 +117,7 @@ export class RailCreationCollector extends BaseMetricsCollector {
   }
 
   private updateTokenMetrics(): void {
+    // Daily token metrics
     const tokenMetric = MetricsEntityManager.loadOrCreateTokenMetric(
       Address.fromBytes(this.rail.token),
       this.timestamp,
@@ -125,6 +126,16 @@ export class RailCreationCollector extends BaseMetricsCollector {
     tokenMetric.activeRailsCount = tokenMetric.activeRailsCount.plus(ONE_BIG_INT);
 
     tokenMetric.save();
+
+    // Weekly token metrics
+    const weeklyTokenMetric = MetricsEntityManager.loadOrCreateWeeklyTokenMetric(
+      Address.fromBytes(this.rail.token),
+      this.timestamp,
+    );
+
+    weeklyTokenMetric.activeRailsCount = weeklyTokenMetric.activeRailsCount.plus(ONE_BIG_INT);
+
+    weeklyTokenMetric.save();
   }
 
   private updateOperatorMetrics(): void {
@@ -218,6 +229,7 @@ export class SettlementCollector extends BaseMetricsCollector {
   }
 
   private updateTokenMetrics(): void {
+    // Daily token metrics
     const tokenMetric = MetricsEntityManager.loadOrCreateTokenMetric(
       Address.fromBytes(this.rail.token),
       this.timestamp,
@@ -228,6 +240,18 @@ export class SettlementCollector extends BaseMetricsCollector {
     tokenMetric.commissionPaid = tokenMetric.commissionPaid.plus(this.operatorCommission);
 
     tokenMetric.save();
+
+    // Weekly token metrics
+    const weeklyTokenMetric = MetricsEntityManager.loadOrCreateWeeklyTokenMetric(
+      Address.fromBytes(this.rail.token),
+      this.timestamp,
+    );
+
+    weeklyTokenMetric.volume = weeklyTokenMetric.volume.plus(this.totalSettledAmount);
+    weeklyTokenMetric.settledAmount = weeklyTokenMetric.settledAmount.plus(this.totalNetPayeeAmount);
+    weeklyTokenMetric.commissionPaid = weeklyTokenMetric.commissionPaid.plus(this.operatorCommission);
+
+    weeklyTokenMetric.save();
   }
 
   private updateNetworkMetrics(): void {
@@ -335,6 +359,7 @@ export class TokenActivityCollector extends BaseMetricsCollector {
   }
 
   private updateTokenMetrics(): void {
+    // Daily token metrics
     const tokenMetric = MetricsEntityManager.loadOrCreateTokenMetric(this.tokenAddress, this.timestamp);
     tokenMetric.volume = tokenMetric.volume.plus(this.amount);
 
@@ -349,6 +374,22 @@ export class TokenActivityCollector extends BaseMetricsCollector {
     }
 
     tokenMetric.save();
+
+    // Weekly token metrics
+    const weeklyTokenMetric = MetricsEntityManager.loadOrCreateWeeklyTokenMetric(this.tokenAddress, this.timestamp);
+    weeklyTokenMetric.volume = weeklyTokenMetric.volume.plus(this.amount);
+
+    if (this.isDeposit) {
+      weeklyTokenMetric.deposit = weeklyTokenMetric.deposit.plus(this.amount);
+    } else {
+      weeklyTokenMetric.withdrawal = weeklyTokenMetric.withdrawal.plus(this.amount);
+    }
+
+    if (this.isNewAccount) {
+      weeklyTokenMetric.uniqueHolders = weeklyTokenMetric.uniqueHolders.plus(ONE_BIG_INT);
+    }
+
+    weeklyTokenMetric.save();
   }
 
   private updateNetworkMetrics(): void {

--- a/subgraph/src/utils/metrics/core.ts
+++ b/subgraph/src/utils/metrics/core.ts
@@ -5,6 +5,7 @@ import {
   DailyTokenMetric,
   PaymentsMetric,
   WeeklyMetric,
+  WeeklyTokenMetric,
 } from "../../../generated/schema";
 import { getPaymentsMetricEntityId } from "../keys";
 import { DateHelpers, ZERO_BIG_INT } from "./constants";
@@ -93,6 +94,30 @@ export class MetricsEntityManager {
       metric.activeRailsCount = ZERO_BIG_INT;
       metric.uniqueHolders = ZERO_BIG_INT;
       metric.totalLocked = ZERO_BIG_INT;
+    }
+
+    return metric;
+  }
+
+  static loadOrCreateWeeklyTokenMetric(tokenAddress: Address, timestamp: GraphBN): WeeklyTokenMetric {
+    const weekStart = DateHelpers.getWeekStartTimestamp(timestamp.toI64());
+    const id = tokenAddress.concat(Bytes.fromByteArray(Bytes.fromI64(weekStart)));
+
+    let metric = WeeklyTokenMetric.load(Bytes.fromByteArray(id));
+
+    if (!metric) {
+      metric = new WeeklyTokenMetric(Bytes.fromByteArray(id));
+      metric.token = tokenAddress;
+      metric.timestamp = GraphBN.fromI64(weekStart);
+      metric.week = DateHelpers.getWeek(weekStart);
+
+      metric.volume = ZERO_BIG_INT;
+      metric.deposit = ZERO_BIG_INT;
+      metric.withdrawal = ZERO_BIG_INT;
+      metric.settledAmount = ZERO_BIG_INT;
+      metric.commissionPaid = ZERO_BIG_INT;
+      metric.activeRailsCount = ZERO_BIG_INT;
+      metric.uniqueHolders = ZERO_BIG_INT;
     }
 
     return metric;


### PR DESCRIPTION
## Summary

- Adds `WeeklyTokenMetric` GraphQL entity to track token-specific metrics aggregated by week
- Enables querying weekly USDFC settled amounts for the Dev Activation Metrics dashboard
- Parallels existing `DailyTokenMetric` entity but with weekly aggregation

## Changes

1. **schema.graphql**: Add `WeeklyTokenMetric` entity with fields:
   - `volume`, `deposit`, `withdrawal` - Token flow metrics
   - `settledAmount`, `commissionPaid` - Settlement metrics
   - `activeRailsCount`, `uniqueHolders` - Utilization metrics

2. **core.ts**: Add `loadOrCreateWeeklyTokenMetric()` method to MetricsEntityManager

3. **collectors.ts**: Update collectors to track weekly token metrics:
   - `SettlementCollector` - Track weekly settled amounts and commission
   - `TokenActivityCollector` - Track weekly deposits/withdrawals
   - `RailCreationCollector` - Track weekly active rails per token

## New Query Example

```graphql
{
  weeklyTokenMetrics(
    where: { token: "0x..." }
    orderBy: timestamp
    orderDirection: desc
  ) {
    week
    timestamp
    settledAmount
    volume
    commissionPaid
  }
}
```

## Test Plan

- [ ] Run `graph codegen` to verify schema compiles
- [ ] Run `graph build` to verify no TypeScript errors
- [ ] Deploy to testnet and verify weeklyTokenMetrics populates on settlement events

🤖 Generated with [Claude Code](https://claude.com/claude-code)