### PR TITLE
fix: correct MRR calculation to use epochs instead of seconds

### DIFF
--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -257,3 +257,43 @@ export interface DailyMetricsResponse {
 export interface AccountDetailResponse {
   account: Account | null;
 }
+
+// Recent settlements query (for Settled 7d metric)
+export const RECENT_SETTLEMENTS_QUERY = gql`
+  query RecentSettlements($since: BigInt!) {
+    settlements(
+      first: 1000
+      where: { timestamp_gte: $since }
+      orderBy: timestamp
+      orderDirection: desc
+    ) {
+      id
+      totalSettledAmount
+      timestamp
+      rail {
+        id
+        payer {
+          address
+        }
+        payee {
+          address
+        }
+      }
+    }
+  }
+`;
+
+export interface Settlement {
+  id: string;
+  totalSettledAmount: string;
+  timestamp: string;
+  rail: {
+    id: string;
+    payer: { address: string };
+    payee: { address: string };
+  };
+}
+
+export interface RecentSettlementsResponse {
+  settlements: Settlement[];
+}


### PR DESCRIPTION
## Summary

- **Bug**: MRR was displaying 30x higher than actual because the calculation used seconds (2,592,000/month) instead of epochs (86,400/month)
- **Root cause**: `paymentRate` in the Filecoin Pay contract is wei per **epoch** (30 sec), not per second
- **Fix**: Changed `SECONDS_PER_MONTH` to `EPOCHS_PER_MONTH` (86,400)

## Evidence

From [FilecoinPayV1.sol](https://github.com/FilOzone/filecoin-pay/blob/main/src/FilecoinPayV1.sol):

```solidity
// In _settleSegmentGross():
uint256 duration = epochEnd - epochStart;
grossSettledAmount = rate * duration;
```

The `duration` is measured in epochs, confirming `paymentRate` is wei/epoch.

## Changes

| Before | After |
|--------|-------|
| `SECONDS_PER_MONTH = 2,592,000` | `EPOCHS_PER_MONTH = 86,400` |
| `// wei per second` | `// wei per epoch` |

Also adds:
- `fetchSettled7d()` helper for 7-day settlement tracking
- `RECENT_SETTLEMENTS_QUERY` for settlement event queries

## Test plan

- [ ] Verify MRR displays reasonable values (should be ~30x lower than before)
- [ ] Cross-check MRR against actual settlement data
- [ ] Verify annualized run rate = monthly × 12

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)