### PR TITLE
feat: upgrade subgraph endpoint to v1.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ npx playwright test
 - **Framework:** Next.js 16 with App Router
 - **Styling:** Tailwind CSS + shadcn/ui components
 - **Charts:** Recharts (sparklines)
-- **Data Source:** Goldsky Subgraph (`filecoin-pay-mainnet/1.0.0`)
+- **Data Source:** Goldsky Subgraph (`filecoin-pay-mainnet/1.1.0`)
 - **Deployment:** Static export to PinMe/IPFS
 
 ## Key Files
@@ -57,7 +57,7 @@ npx playwright test
 
 Goldsky Subgraph endpoint:
 ```
-https://api.goldsky.com/api/public/project_cmb9tuo8r1xdw01ykb8uidk7h/subgraphs/filecoin-pay-mainnet/1.0.0/gn
+https://api.goldsky.com/api/public/project_cmj7soo5uf4no01xw0tij21a1/subgraphs/filecoin-pay-mainnet/1.1.0/gn
 ```
 
 Key entities: `paymentsMetrics`, `accounts`, `rails`, `dailyMetrics`, `settlements`

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ npm run build   # Production build (static export to /out)
 
 **Endpoint:**
 ```
-https://api.goldsky.com/api/public/project_cmb9tuo8r1xdw01ykb8uidk7h/subgraphs/filecoin-pay-mainnet/1.0.0/gn
+https://api.goldsky.com/api/public/project_cmj7soo5uf4no01xw0tij21a1/subgraphs/filecoin-pay-mainnet/1.1.0/gn
 ```
 
 **Network:** Filecoin Mainnet
 **Contract:** `0x23b1e018F08BB982348b15a86ee926eEBf7F4DAa` ([View on Filfox](https://filfox.info/en/address/0x23b1e018F08BB982348b15a86ee926eEBf7F4DAa))
-**Subgraph Version:** 1.0.0
+**Subgraph Version:** 1.1.0
 
 ---
 

--- a/lib/graphql/client.ts
+++ b/lib/graphql/client.ts
@@ -1,9 +1,9 @@
 import { GraphQLClient } from 'graphql-request';
 
 // Data source configuration - Filecoin Mainnet
-export const GOLDSKY_ENDPOINT = 'https://api.goldsky.com/api/public/project_cmb9tuo8r1xdw01ykb8uidk7h/subgraphs/filecoin-pay-mainnet/1.0.0/gn';
+export const GOLDSKY_ENDPOINT = 'https://api.goldsky.com/api/public/project_cmj7soo5uf4no01xw0tij21a1/subgraphs/filecoin-pay-mainnet/1.1.0/gn';
 export const FILECOIN_PAY_CONTRACT = '0x23b1e018F08BB982348b15a86ee926eEBf7F4DAa';
-export const SUBGRAPH_VERSION = '1.0.0';
+export const SUBGRAPH_VERSION = '1.1.0';
 export const NETWORK = 'Filecoin Mainnet';
 
 // Filecoin epoch constants


### PR DESCRIPTION
## Summary

- Upgrade Filecoin Pay subgraph endpoint from v1.0.0 to v1.1.0
- Both endpoints return identical data (verified synced to same block)
- Aligns with metrics documentation standard

## Changes

- `lib/graphql/client.ts`: Update endpoint URL and version constant
- `README.md`: Update documented endpoint
- `CLAUDE.md`: Update documented endpoint

## Test Plan

- [x] `npm run build` passes
- [x] New endpoint returns valid data (verified via curl)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)