### PR TITLE
Fix: Point subgraph config to working endpoints (#77)

### DIFF
--- a/lib/config/network.ts
+++ b/lib/config/network.ts
@@ -13,7 +13,7 @@ const NETWORKS = {
     chain: filecoin,
     rpc: 'https://api.node.glif.io/rpc/v1',
     subgraphs: {
-      FILECOIN_PAY: { name: 'filecoin-pay-mainnet-tim', version: '1.2.0' },
+      FILECOIN_PAY: { name: 'filecoin-pay-mainnet', version: '1.0.6' },
       FWSS: { name: 'fwss-mainnet-tim', version: '1.1.0' },
     },
     contracts: {
@@ -27,7 +27,7 @@ const NETWORKS = {
     chain: filecoinCalibration,
     rpc: 'https://api.calibration.node.glif.io/rpc/v1',
     subgraphs: {
-      FILECOIN_PAY: { name: 'filecoin-pay-calibration-tim', version: '1.2.0' },
+      FILECOIN_PAY: { name: 'filecoin-pay-calibration', version: '1.0.6' },
       FWSS: { name: 'fwss-calibration-tim', version: '1.0.0' },
     },
     contracts: {


### PR DESCRIPTION
Closes #77

## Summary
- Mainnet FILECOIN_PAY subgraph: `filecoin-pay-mainnet-tim` v1.2.0 (deleted/404) → `filecoin-pay-mainnet` v1.0.6 (working)
- Calibration FILECOIN_PAY subgraph: `filecoin-pay-calibration-tim` v1.2.0 (deleted/404) → `filecoin-pay-calibration` v1.0.6 (working)
- FWSS subgraphs unchanged (mainnet already works, calibration has no working alternative)

## Test plan
- [x] Verified v1.0.6 endpoints return data via curl
- [x] Local dev server (`npm run dev:prototype`) loads Payer Accounts page with 74 payers, hero metrics, and time-series charts
- [ ] Verify Vercel preview deployment loads `/payer-accounts/` with data
- [ ] Verify dashboard `/` hero metrics still populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)