### PR TITLE
Fix broken Payer Detail page (remove v1.2.0 subgraph fields)

### DIFF
--- a/lib/graphql/fetchers/accounts.ts
+++ b/lib/graphql/fetchers/accounts.ts
@@ -79,8 +79,6 @@ export interface AccountDetail {
 function transformRailToDisplay(rail: Rail, isPayer: boolean, accountAddress: string): RailDisplay {
   const counterparty = isPayer ? rail.payee?.address : rail.payer?.address;
   const settledValue = weiToUSDC(rail.totalSettledAmount);
-  const netPayeeValue = rail.totalNetPayeeAmount ? weiToUSDC(rail.totalNetPayeeAmount) : settledValue;
-  const commissionValue = rail.totalCommission ? weiToUSDC(rail.totalCommission) : 0;
   const rateValue = rail.paymentRate ? weiToUSDC(rail.paymentRate) : 0;
   const createdAtMs = secondsToMs(rail.createdAt);
 
@@ -111,10 +109,10 @@ function transformRailToDisplay(rail: Rail, isPayer: boolean, accountAddress: st
     payeeAddress,
     settled: formatCurrency(settledValue),
     settledRaw: settledValue,
-    netPayeeAmount: formatCurrency(netPayeeValue),
-    netPayeeAmountRaw: netPayeeValue,
-    commission: formatCurrency(commissionValue),
-    commissionRaw: commissionValue,
+    netPayeeAmount: formatCurrency(settledValue),
+    netPayeeAmountRaw: settledValue,
+    commission: formatCurrency(0),
+    commissionRaw: 0,
     rate: rateValue > 0 ? `${formatCurrency(rateValue)}/epoch` : '-',
     rateRaw: rateValue,
     state: stateLabel,

--- a/lib/graphql/fetchers/payees.ts
+++ b/lib/graphql/fetchers/payees.ts
@@ -43,15 +43,12 @@ export interface PayeeDisplay {
  */
 function transformAccountToPayee(account: Account, pdpData?: PDPEnrichment | null): PayeeDisplay {
   // Sum up received from all payee rails
-  // Use totalNetPayeeAmount (net after fees) for accurate payee totals
   let totalReceived = BigInt(0);
   let earliestDate = Date.now();
   const uniquePayers = new Set<string>();
 
   for (const rail of account.payeeRails || []) {
-    // Prefer totalNetPayeeAmount (net to payee after fees)
-    // Fall back to totalSettledAmount if not available
-    const amount = rail.totalNetPayeeAmount || rail.totalSettledAmount;
+    const amount = rail.totalSettledAmount;
     totalReceived += BigInt(amount);
     const createdAt = secondsToMs(rail.createdAt);
     if (createdAt < earliestDate) {

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -127,8 +127,6 @@ export const TOP_PAYEES_QUERY = gql`
         id
         railId
         totalSettledAmount
-        totalNetPayeeAmount
-        totalCommission
         settledUpto
         createdAt
         state
@@ -167,8 +165,6 @@ export const ACCOUNT_DETAIL_QUERY = gql`
         id
         railId
         totalSettledAmount
-        totalNetPayeeAmount
-        totalCommission
         settledUpto
         paymentRate
         state
@@ -185,8 +181,6 @@ export const ACCOUNT_DETAIL_QUERY = gql`
         id
         railId
         totalSettledAmount
-        totalNetPayeeAmount
-        totalCommission
         settledUpto
         paymentRate
         state
@@ -229,8 +223,6 @@ export interface Rail {
   id: string;
   railId?: string;
   totalSettledAmount: string;
-  totalNetPayeeAmount?: string;
-  totalCommission?: string;
   settledUpto?: string;
   createdAt: string;
   state: number | string;


### PR DESCRIPTION
## Finalized Spec

### Goal
Fix the broken Payer Detail page by removing subgraph fields that don't exist in production v1.0.6.

### Requirements
- Remove `totalNetPayeeAmount` and `totalCommission` from all GraphQL queries
- Use `totalSettledAmount` everywhere (gross amount before commission split)
- Clean up fetcher fallback logic

### Acceptance Criteria
- [ ] Payer Detail page loads for Storacha (`0x3c1ae7a70a2b51458fcb7927fd77aae408a1b857`)
- [ ] Summary cards display data
- [ ] Payment Rails table renders with settled amounts
- [ ] Payee Accounts page loads without errors
- [ ] No console errors related to subgraph field mismatches

## Implementation

- Removed `totalNetPayeeAmount` and `totalCommission` from `ACCOUNT_DETAIL_QUERY`, `TOP_PAYEES_QUERY`, and `Rail` type interface
- Updated `accounts.ts` fetcher to use `settledValue` directly instead of fallback logic
- Updated `payees.ts` fetcher to use `totalSettledAmount` directly

**Files modified:** `lib/graphql/queries.ts`, `lib/graphql/fetchers/accounts.ts`, `lib/graphql/fetchers/payees.ts`

## Test Plan

- [ ] Vercel preview deployment works
- [ ] Playwright validation: payer detail page loads with data
- [ ] Playwright validation: payee accounts page loads without errors

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update GraphQL queries and fetchers to rely solely on settled amounts now supported by the production subgraph.

Bug Fixes:
- Remove usage of non-existent subgraph fields from account and payee queries to restore Payer and Payee detail pages.

Enhancements:
- Standardize rail display and payee aggregation logic to use totalSettledAmount and a zero commission placeholder instead of fallback logic based on optional net/commission fields.