### PR TITLE
Remove Active Payers time series chart

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -389,40 +389,8 @@ export default function Dashboard() {
 
       {/* Cumulative Line Charts */}
       {chartData.length > 0 && (
-        <div className="grid grid-cols-2 gap-6">
-          {/* Chart 1: Total Active Payers */}
-          <div className="bg-white border rounded-lg p-4">
-            <h3 className="text-lg font-semibold mb-2">Total Active Payers</h3>
-            <p className="text-sm text-gray-500 mb-4">
-              Cumulative count of active payer wallets (ACTIVE rail AND lockup rate &gt; 0)
-            </p>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={chartData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-                  <XAxis
-                    dataKey="date"
-                    tick={{ fontSize: 12 }}
-                    tickFormatter={formatChartDate}
-                  />
-                  <YAxis tick={{ fontSize: 12 }} />
-                  <Tooltip
-                    formatter={(value) => [value ?? 0, "Active Payers"]}
-                    labelFormatter={(label) => `Date: ${label}`}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="payers"
-                    stroke="#3b82f6"
-                    strokeWidth={2}
-                    dot={false}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
-
-          {/* Chart 2: Total USDFC Settled */}
+        <div className="grid grid-cols-1 gap-6">
+          {/* Total USDFC Settled */}
           <div className="bg-white border rounded-lg p-4">
             <h3 className="text-lg font-semibold mb-2">Total USDFC Settled</h3>
             <p className="text-sm text-gray-500 mb-4">


### PR DESCRIPTION
## Summary
- Removes the "Total Active Payers" cumulative line chart from the Dashboard
- USDFC Settled chart remains, now full-width (grid-cols-1)
- Chart data was inaccurate per #85 — flat line due to bucketing current-state active payers at their earliest rail creation date

## Test Plan
- [ ] Vercel preview shows Dashboard without Active Payers chart
- [ ] USDFC Settled chart renders correctly at full width
- [ ] No build errors

Closes #86
Blocked by #85 for re-adding with accurate data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Simplify the dashboard layout by switching the cumulative charts section to a single-column grid with only the USDFC Settled chart displayed.