### PR TITLE
Add per-piece cost to DataSet cards via FWSS subgraph

### DIFF
--- a/app/payer-accounts/page.tsx
+++ b/app/payer-accounts/page.tsx
@@ -26,20 +26,13 @@ import {
 } from "@/lib/graphql/client";
 import { batchResolveENS, resolveENS } from "@/lib/ens";
 import {
-  fetchDataSetsWithRootsByCorrelation,
-  calculateStorageSummary,
-  formatBytesSize,
-  transformDataSetsToDisplay,
   calculateDataSetsSummary,
-  RailInfoForDataSet,
 } from "@/lib/pdp/fetchers";
-import { RailDataSetCorrelation, DataSetDisplayData } from "@/lib/pdp/types";
-import { PDPDataSetWithRoots, PieceDisplayData } from "@/lib/pdp/types";
+import { DataSetDisplayData, PieceDisplayData } from "@/lib/pdp/types";
 import {
-  fetchPieceMetadata,
-  hexCidToBase32,
   truncateCID,
 } from "@/lib/stateview/client";
+import { fetchFWSSDataSetsForPayer } from "@/lib/fwss/fetchers";
 import {
   Table,
   TableBody,
@@ -210,7 +203,6 @@ function PayerDetailView({ address }: { address: string }) {
   };
 
   // My Data state
-  const [dataSets, setDataSets] = useState<PDPDataSetWithRoots[]>([]);
   const [pieceData, setPieceData] = useState<PieceDisplayData[]>([]);
   const [dataSetDisplay, setDataSetDisplay] = useState<DataSetDisplayData[]>([]);
   const [dataLoading, setDataLoading] = useState(false);
@@ -307,40 +299,17 @@ function PayerDetailView({ address }: { address: string }) {
     if (!address || !account || loading) return;
 
     async function loadMyData() {
-      // Re-check account since it could change during async execution
       if (!account) return;
 
       try {
         setDataLoading(true);
 
-        // Build rail correlations from account's payer rails
-        // DataSets are owned by SPs (payees), so we correlate by payee + timestamp
-        const railCorrelations: RailDataSetCorrelation[] = account.payerRails.map(rail => ({
-          payeeAddress: rail.counterpartyAddress,
-          railCreatedAt: Math.floor(rail.createdAtTimestamp / 1000).toString(), // Convert ms to seconds
-        }));
-
-        // Build rail info for payment calculations
-        const railsInfo: RailInfoForDataSet[] = account.payerRails.map(rail => ({
-          railId: rail.railId,
-          payeeAddress: rail.counterpartyAddress,
-          createdAtTimestamp: rail.createdAtTimestamp,
-          paymentRateWei: rail.paymentRate,
-        }));
-
-        // Fetch DataSets with roots using rail correlations
-        const fetchedDataSets = await fetchDataSetsWithRootsByCorrelation(railCorrelations);
-        setDataSets(fetchedDataSets);
-
-        // Transform to DataSetDisplayData using the new function
-        const displayData = transformDataSetsToDisplay(
-          fetchedDataSets,
-          railsInfo,
-          hexCidToBase32
-        );
+        // Fetch datasets from FWSS subgraph (has direct payer field + pieces with CIDs)
+        // Automatically joins with Filecoin Pay rails via pdpRailId for cost data
+        const displayData = await fetchFWSSDataSetsForPayer(address);
         setDataSetDisplay(displayData);
 
-        // Extract all pieces for legacy pieceData (used by CID search)
+        // Extract all pieces for CID search
         const allPieces: PieceDisplayData[] = displayData.flatMap(ds => ds.pieces);
         setPieceData(allPieces);
 
@@ -350,44 +319,11 @@ function PayerDetailView({ address }: { address: string }) {
           const ensNames = await batchResolveENS(providerAddresses);
           setProviderEnsNames(ensNames);
 
-          // Update dataSetDisplay with ENS names
           setDataSetDisplay(prev => prev.map(ds => ({
             ...ds,
             providerENS: ensNames.get(ds.providerAddress.toLowerCase()) || null,
           })));
         }
-
-        // Fetch IPFS CIDs from StateView (in background, may be slow)
-        const enrichedPieces = await Promise.all(
-          allPieces.map(async (piece) => {
-            try {
-              const metadata = await fetchPieceMetadata(piece.dataSetId, piece.pieceId);
-              return {
-                ...piece,
-                ipfsCID: metadata.ipfsRootCID,
-              };
-            } catch {
-              return piece;
-            }
-          })
-        );
-
-        setPieceData(enrichedPieces);
-
-        // Also update pieces in dataSetDisplay with IPFS CIDs
-        const pieceCidMap = new Map<string, string>();
-        for (const p of enrichedPieces) {
-          if (p.ipfsCID) {
-            pieceCidMap.set(`${p.dataSetId}-${p.pieceId}`, p.ipfsCID);
-          }
-        }
-        setDataSetDisplay(prev => prev.map(ds => ({
-          ...ds,
-          pieces: ds.pieces.map(p => ({
-            ...p,
-            ipfsCID: pieceCidMap.get(`${p.dataSetId}-${p.pieceId}`) || p.ipfsCID,
-          })),
-        })));
 
       } catch (err) {
         console.error("Failed to load My Data:", err);
@@ -408,12 +344,11 @@ function PayerDetailView({ address }: { address: string }) {
 
     const query = cidSearchQuery.trim().toLowerCase();
 
-    // Search in pieceData
+    // Search in pieceData by Piece CID (commP)
     const found = pieceData.find(
       (p) =>
         p.pieceCID.toLowerCase().includes(query) ||
-        p.pieceCIDHex.toLowerCase().includes(query) ||
-        (p.ipfsCID && p.ipfsCID.toLowerCase().includes(query))
+        p.pieceCIDHex.toLowerCase().includes(query)
     );
 
     if (found) {
@@ -428,8 +363,28 @@ function PayerDetailView({ address }: { address: string }) {
 
   // Calculate storage summary
   const storageSummary = useMemo(() => {
-    return calculateStorageSummary(dataSets);
-  }, [dataSets]);
+    // Derive storage summary from FWSS display data
+    let totalStorageBytes = BigInt(0);
+    let totalPieces = 0;
+    for (const ds of dataSetDisplay) {
+      totalStorageBytes += ds.totalSizeBytes;
+      totalPieces += ds.pieceCount;
+    }
+    const totalStorageGB = Number(totalStorageBytes) / (1024 ** 3);
+    return {
+      totalStorageBytes,
+      totalStorageFormatted: totalStorageGB >= 1024
+        ? `${(totalStorageGB / 1024).toFixed(2)} TB`
+        : totalStorageGB >= 1
+        ? `${totalStorageGB.toFixed(2)} GB`
+        : totalStorageGB > 0
+        ? `${(totalStorageGB * 1024).toFixed(2)} MB`
+        : '-',
+      totalPieces,
+      totalDataSets: dataSetDisplay.length,
+      runwayDays: null as number | null,
+    };
+  }, [dataSetDisplay]);
 
   // Calculate DataSets summary with payment info
   const dataSetsSummary = useMemo(() => {
@@ -605,7 +560,7 @@ function PayerDetailView({ address }: { address: string }) {
           <div className="flex items-center gap-4">
             <input
               type="text"
-              placeholder="Enter IPFS CID or Piece CID to lookup..."
+              placeholder="Enter Piece CID to lookup..."
               value={cidSearchQuery}
               onChange={(e) => {
                 setCidSearchQuery(e.target.value);
@@ -626,7 +581,7 @@ function PayerDetailView({ address }: { address: string }) {
             </button>
           </div>
           <p className="text-xs text-gray-500 mt-2">
-            Supports bidirectional lookup: IPFS CID → Piece CID or Piece CID → IPFS CID
+            Search by Piece CID (commP) across all DataSets
           </p>
 
           {/* Search Result */}
@@ -639,11 +594,11 @@ function PayerDetailView({ address }: { address: string }) {
                   <span className="font-mono">{truncateCID(cidSearchResult.pieceCID)}</span>
                 </div>
                 <div>
-                  <span className="text-gray-500">IPFS CID:</span>{" "}
-                  <span className="font-mono">{cidSearchResult.ipfsCID ? truncateCID(cidSearchResult.ipfsCID) : "—"}</span>
+                  <span className="text-gray-500">Size:</span> {cidSearchResult.size}
                 </div>
                 <div>
-                  <span className="text-gray-500">Size:</span> {cidSearchResult.size}
+                  <span className="text-gray-500">Cost/mo:</span>{" "}
+                  <span className="font-medium">{cidSearchResult.costPerMonth !== null ? `$${cidSearchResult.costPerMonth.toFixed(4)}` : "—"}</span>
                 </div>
                 <div>
                   <span className="text-gray-500">Provider:</span>{" "}
@@ -677,9 +632,9 @@ function PayerDetailView({ address }: { address: string }) {
           </div>
         )}
 
-        {/* Note about IPFS CID */}
+        {/* Note about cost calculation */}
         <p className="text-xs text-gray-400">
-          Note: IPFS CID shows &quot;—&quot; when not set (Synapse SDK users). Piece CID is always available.
+          Per-piece costs are size-weighted from the rail payment rate. Total settled reflects on-chain settlement amounts.
         </p>
       </div>
 

--- a/components/payer/DataSetCard.tsx
+++ b/components/payer/DataSetCard.tsx
@@ -204,8 +204,9 @@ export function DataSetCard({
                 <TableHeader>
                   <TableRow className="bg-gray-50">
                     <TableHead className="font-medium">Piece CID</TableHead>
-                    <TableHead className="font-medium">IPFS CID</TableHead>
                     <TableHead className="font-medium">Size</TableHead>
+                    <TableHead className="font-medium text-right">Cost/mo</TableHead>
+                    <TableHead className="font-medium text-right">Total Settled</TableHead>
                     <TableHead className="font-medium">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -243,50 +244,28 @@ function PieceRow({ piece, index }: { piece: PieceDisplayData; index: number }) 
           </button>
         </div>
       </TableCell>
-      <TableCell>
-        {piece.ipfsCID ? (
-          <div className="flex items-center gap-2">
-            <span className="font-mono text-sm" title={piece.ipfsCID}>
-              {truncateCID(piece.ipfsCID)}
-            </span>
-            <button
-              onClick={() => navigator.clipboard.writeText(piece.ipfsCID!)}
-              className="text-gray-400 hover:text-gray-600"
-              title="Copy IPFS CID"
-            >
-              📋
-            </button>
-          </div>
-        ) : (
-          <span className="text-gray-400">—</span>
-        )}
-      </TableCell>
       <TableCell>{piece.size}</TableCell>
+      <TableCell className="text-right">
+        {piece.costPerMonth !== null && piece.costPerMonth !== undefined
+          ? formatCurrency(piece.costPerMonth)
+          : <span className="text-gray-400">—</span>}
+      </TableCell>
+      <TableCell className="text-right">
+        {piece.totalSettled !== null && piece.totalSettled !== undefined
+          ? formatCurrency(piece.totalSettled)
+          : <span className="text-gray-400">—</span>}
+      </TableCell>
       <TableCell>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => {
-              const url = piece.ipfsCID
-                ? `https://dweb.link/ipfs/${piece.ipfsCID}`
-                : `https://data.filecoin.io/piece/${piece.pieceCID}`;
-              navigator.clipboard.writeText(url);
-            }}
-            className="text-blue-600 hover:underline text-sm"
-            title="Copy retrieval URL"
-          >
-            Copy URL
-          </button>
-          {piece.ipfsCID && (
-            <a
-              href={`https://dweb.link/ipfs/${piece.ipfsCID}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:underline text-sm"
-            >
-              View
-            </a>
-          )}
-        </div>
+        <button
+          onClick={() => {
+            const url = `https://data.filecoin.io/piece/${piece.pieceCID}`;
+            navigator.clipboard.writeText(url);
+          }}
+          className="text-blue-600 hover:underline text-sm"
+          title="Copy retrieval URL"
+        >
+          Copy URL
+        </button>
       </TableCell>
     </TableRow>
   );

--- a/lib/fwss/fetchers.ts
+++ b/lib/fwss/fetchers.ts
@@ -1,0 +1,311 @@
+/**
+ * FWSS (Filecoin Warm Storage Service) subgraph client.
+ *
+ * Queries FWSS for datasets and pieces by payer address, then joins with
+ * Filecoin Pay rails via pdpRailId for payment/cost data.
+ *
+ * Unlike PDP (which owns datasets by SP address), FWSS has a direct
+ * `payer` field on DataSet, enabling straightforward payer-filtered queries.
+ */
+
+import { SUBGRAPHS } from '../graphql/client';
+import { GOLDSKY_ENDPOINT } from '../graphql/client';
+import {
+  DataSetDisplayData,
+  PieceDisplayData,
+} from '../pdp/types';
+import { formatBytesSize, formatTimeAgo } from '../pdp/fetchers';
+
+// FWSS subgraph endpoint
+const FWSS_ENDPOINT = SUBGRAPHS.FWSS.endpoint;
+
+// ── Raw FWSS response types ──────────────────────────────────────────
+
+interface FWSSPiece {
+  pieceCID: string;   // CommP CID, base32 (bafkz...)
+  size: string;       // Bytes as string
+}
+
+interface FWSSDataSet {
+  dataSetId: string;
+  payer: { id: string };
+  payee: { id: string };
+  totalPieces: number;
+  totalSize: string;     // Bytes as string
+  pdpRailId: string;     // Join key to Filecoin Pay
+  cacheMissRailId: string | null;
+  cdnRailId: string | null;
+  status: string;        // "Active" | "Terminated"
+  pieces: FWSSPiece[];
+}
+
+interface FWSSDataSetsResponse {
+  dataSets: FWSSDataSet[];
+}
+
+// ── Filecoin Pay rail types ──────────────────────────────────────────
+
+interface FilPayRail {
+  id: string;          // Hex ID (0x01)
+  railId: string;      // Numeric string
+  paymentRate: string;  // Wei per second
+  totalSettledAmount: string; // Wei
+  createdAt: string;    // Unix timestamp
+  payer: { address: string };
+  payee: { address: string };
+  token: { symbol: string; decimals: number };
+  state: string;
+}
+
+interface FilPayRailsResponse {
+  rails: FilPayRail[];
+}
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const BYTES_PER_GB = 1024 ** 3;
+const SECONDS_PER_MONTH = 30 * 24 * 60 * 60;
+
+// ── GraphQL queries ──────────────────────────────────────────────────
+
+const FWSS_DATASETS_BY_PAYER = `
+  query DataSetsByPayer($payerAddress: String!, $first: Int!, $skip: Int!) {
+    dataSets(
+      where: { payer: $payerAddress }
+      first: $first
+      skip: $skip
+      orderBy: dataSetId
+      orderDirection: desc
+    ) {
+      dataSetId
+      payer { id }
+      payee { id }
+      totalPieces
+      totalSize
+      pdpRailId
+      cacheMissRailId
+      cdnRailId
+      status
+      pieces(first: 1000) {
+        pieceCID
+        size
+      }
+    }
+  }
+`;
+
+const FILPAY_RAILS_BY_IDS = `
+  query RailsByIds($railIds: [String!]!) {
+    rails(where: { railId_in: $railIds }) {
+      id
+      railId
+      paymentRate
+      totalSettledAmount
+      createdAt
+      payer { address }
+      payee { address }
+      token { symbol decimals }
+      state
+    }
+  }
+`;
+
+// ── Fetch helpers ────────────────────────────────────────────────────
+
+async function queryFWSS<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const response = await fetch(FWSS_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`FWSS query failed: HTTP ${response.status}`);
+  }
+
+  const json = await response.json();
+  if (json.data) return json.data as T;
+
+  const msg = json.errors?.map((e: { message: string }) => e.message).join('; ') || 'Unknown FWSS error';
+  throw new Error(msg);
+}
+
+async function queryFilPay<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const response = await fetch(GOLDSKY_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`FilPay query failed: HTTP ${response.status}`);
+  }
+
+  const json = await response.json();
+  if (json.data) return json.data as T;
+
+  const msg = json.errors?.map((e: { message: string }) => e.message).join('; ') || 'Unknown FilPay error';
+  throw new Error(msg);
+}
+
+// ── Main fetcher ─────────────────────────────────────────────────────
+
+/**
+ * Fetch FWSS datasets for a payer address, joined with Filecoin Pay
+ * rail data for cost calculations.
+ *
+ * Returns DataSetDisplayData[] with per-piece cost fields populated.
+ */
+export async function fetchFWSSDataSetsForPayer(
+  payerAddress: string
+): Promise<DataSetDisplayData[]> {
+  const normalizedPayer = payerAddress.toLowerCase();
+
+  // 1. Fetch all datasets from FWSS for this payer
+  let allDataSets: FWSSDataSet[] = [];
+  let skip = 0;
+  const PAGE_SIZE = 100;
+
+  while (true) {
+    const data = await queryFWSS<FWSSDataSetsResponse>(FWSS_DATASETS_BY_PAYER, {
+      payerAddress: normalizedPayer,
+      first: PAGE_SIZE,
+      skip,
+    });
+
+    if (!data.dataSets || data.dataSets.length === 0) break;
+    allDataSets = allDataSets.concat(data.dataSets);
+    if (data.dataSets.length < PAGE_SIZE) break;
+    skip += PAGE_SIZE;
+  }
+
+  if (allDataSets.length === 0) return [];
+
+  // 2. Collect unique rail IDs for Filecoin Pay lookup
+  const railIds = new Set<string>();
+  for (const ds of allDataSets) {
+    if (ds.pdpRailId) railIds.add(ds.pdpRailId);
+    if (ds.cacheMissRailId) railIds.add(ds.cacheMissRailId);
+    if (ds.cdnRailId) railIds.add(ds.cdnRailId);
+  }
+
+  // 3. Fetch rail data from Filecoin Pay
+  const railMap = new Map<string, FilPayRail>();
+  if (railIds.size > 0) {
+    try {
+      const railData = await queryFilPay<FilPayRailsResponse>(FILPAY_RAILS_BY_IDS, {
+        railIds: Array.from(railIds),
+      });
+      for (const rail of railData.rails || []) {
+        railMap.set(rail.railId, rail);
+      }
+    } catch (error) {
+      console.error('Failed to fetch Filecoin Pay rails for FWSS join:', error);
+    }
+  }
+
+  const now = Date.now();
+
+  // 4. Transform to DataSetDisplayData
+  return allDataSets.map((ds) => {
+    const providerAddress = ds.payee.id;
+    const totalSizeBytes = BigInt(ds.totalSize);
+    const totalSizeNum = Number(totalSizeBytes);
+
+    // Get primary rail (pdpRailId) for cost calculations
+    const rail = ds.pdpRailId ? railMap.get(ds.pdpRailId) : undefined;
+
+    let totalPaidUSDFC = 0;
+    let costPerGBMonth: number | null = null;
+    let paymentRatePerSecond = BigInt(0);
+    let railCreatedAtMs = 0;
+
+    // Also accumulate totalSettledAmount from rail
+    let railTotalSettled = 0;
+
+    if (rail) {
+      paymentRatePerSecond = BigInt(rail.paymentRate);
+      railCreatedAtMs = parseInt(rail.createdAt) * 1000;
+
+      // Total paid = rate × duration
+      const durationSeconds = Math.floor((now - railCreatedAtMs) / 1000);
+      if (durationSeconds > 0 && paymentRatePerSecond > BigInt(0)) {
+        const totalPaidWei = paymentRatePerSecond * BigInt(durationSeconds);
+        totalPaidUSDFC = Number(totalPaidWei) / 1e18;
+      }
+
+      // Total settled from subgraph (actual on-chain settlements)
+      railTotalSettled = Number(BigInt(rail.totalSettledAmount)) / 1e18;
+
+      // Cost per GB per month
+      const sizeGB = totalSizeNum / BYTES_PER_GB;
+      if (sizeGB > 0 && paymentRatePerSecond > BigInt(0)) {
+        const monthlyWei = paymentRatePerSecond * BigInt(SECONDS_PER_MONTH);
+        const monthlyUSDFC = Number(monthlyWei) / 1e18;
+        costPerGBMonth = Math.round((monthlyUSDFC / sizeGB) * 100) / 100;
+      }
+    }
+
+    // Transform pieces with size-weighted cost
+    const pieces: PieceDisplayData[] = ds.pieces.map((piece, index) => {
+      const sizeBytes = BigInt(piece.size);
+      const sizeNum = Number(sizeBytes);
+      const sizeWeight = totalSizeNum > 0 ? sizeNum / totalSizeNum : 0;
+
+      let costPerMonth: number | null = null;
+      let totalSettled: number | null = null;
+
+      if (rail && paymentRatePerSecond > BigInt(0)) {
+        // Size-weighted monthly cost
+        const monthlyWei = paymentRatePerSecond * BigInt(SECONDS_PER_MONTH);
+        const monthlyUSDFC = Number(monthlyWei) / 1e18;
+        costPerMonth = Math.round(monthlyUSDFC * sizeWeight * 10000) / 10000;
+
+        // Size-weighted total settled
+        totalSettled = Math.round(railTotalSettled * sizeWeight * 10000) / 10000;
+      }
+
+      return {
+        dataSetId: ds.dataSetId,
+        pieceId: String(index),
+        pieceCID: piece.pieceCID,
+        pieceCIDHex: '',  // FWSS provides base32 natively
+        ipfsCID: null,
+        size: formatBytesSize(sizeBytes),
+        sizeBytes,
+        provider: providerAddress,
+        providerFormatted: formatAddress(providerAddress),
+        isActive: ds.status === 'Active',
+        costPerMonth,
+        totalSettled,
+      };
+    });
+
+    return {
+      setId: ds.dataSetId,
+      providerAddress,
+      providerENS: null,
+      providerFormatted: formatAddress(providerAddress),
+      totalSizeBytes,
+      totalSizeFormatted: formatBytesSize(totalSizeBytes),
+      pieceCount: ds.totalPieces,
+      isActive: ds.status === 'Active',
+      lastProvenEpoch: null,  // FWSS doesn't track proving
+      lastProvenFormatted: null,
+      hasFaults: false,
+      faultedPeriods: 0,
+      createdAt: '',
+      railId: ds.pdpRailId || null,
+      paymentRatePerSecond,
+      railCreatedAtMs,
+      totalPaidUSDFC: Math.round(totalPaidUSDFC * 100) / 100,
+      costPerGBMonth,
+      pieces,
+    };
+  });
+}
+
+function formatAddress(address: string): string {
+  if (!address || address.length < 10) return address || '—';
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}

--- a/lib/pdp/fetchers.ts
+++ b/lib/pdp/fetchers.ts
@@ -713,6 +713,8 @@ export function transformDataSetsToDisplay(
         provider: providerAddress,
         providerFormatted: formatAddress(providerAddress),
         isActive: ds.isActive,
+        costPerMonth: null,
+        totalSettled: null,
       };
     });
 

--- a/lib/pdp/types.ts
+++ b/lib/pdp/types.ts
@@ -125,6 +125,8 @@ export interface PieceDisplayData {
   provider: string;         // SP address
   providerFormatted: string; // Truncated or ENS
   isActive: boolean;
+  costPerMonth: number | null;   // Size-weighted monthly cost in USDFC
+  totalSettled: number | null;   // Size-weighted total settled in USDFC
 }
 
 /**


### PR DESCRIPTION
## Summary

- Switch payer detail "My Data" data source from PDP to **FWSS subgraph v1.1.0**
- Add **per-piece cost columns** (Cost/mo, Total Settled) to the expandable pieces table
- Costs are **size-weighted** from the rail payment rate via `pdpRailId` join
- Remove IPFS CID column — focus on commP CIDs only

## Data Flow

```
FWSS (v1.1.0)                         Filecoin Pay (v1.0.6)
─────────────                          ─────────────────────
dataSets(payer: address)               rails(railId_in: [...])
  → pieces[]: pieceCID, size            → paymentRate, totalSettledAmount
  → pdpRailId ────────────────────────→ railId (join key)

Per-piece cost = (piece.size / dataset.totalSize) × rail.monthlyRate
Per-piece settled = (piece.size / dataset.totalSize) × rail.totalSettled
```

## Files Changed

| File | Change |
|------|--------|
| `lib/fwss/fetchers.ts` | **New** — FWSS fetcher with cross-subgraph rail join |
| `lib/pdp/types.ts` | Add `costPerMonth`, `totalSettled` to `PieceDisplayData` |
| `components/payer/DataSetCard.tsx` | Add cost columns, remove IPFS CID column |
| `app/payer-accounts/page.tsx` | Switch from PDP to FWSS, simplify data loading |
| `lib/pdp/fetchers.ts` | Add new fields to existing transform (backward compat) |

## Test Plan

- [ ] Vercel preview deployment works
- [ ] Payer detail page loads DataSet cards with pieces
- [ ] Per-piece Cost/mo and Total Settled columns display values
- [ ] CID search works with commP CIDs
- [ ] Known payer wallets (Storacha, Tippy, PinMe) show correct data

Closes #89
Implements FilOzone/filecoin-pay-console-stories#320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch payer DataSet loading to the FWSS subgraph and surface per-piece cost metrics on DataSet views.

New Features:
- Expose per-piece monthly cost and total settled amounts for dataset pieces in payer views.
- Add a FWSS subgraph-backed fetcher that joins datasets to Filecoin Pay rails for cost calculations.

Enhancements:
- Replace PDP-based payer dataset loading with a FWSS-based flow that simplifies correlation logic.
- Derive storage summary metrics directly from FWSS display data instead of PDP datasets.
- Update CID search UI and behavior to focus solely on commP piece CIDs and show cost information for matches.