### PR TITLE
Add shimmer while wallet names resolve

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { DataSourcePanel } from "@/components/dashboard/DataSourcePanel";
 import { fetchDashboardData, fetchChurnedWalletsCount, formatChartDate, formatChartCurrency, FILMetricsResult } from "@/lib/graphql/fetchers";
 import { OperatorDisplay } from "@/lib/graphql/fetchers/operators";
 import { batchResolveENS } from "@/lib/ens";
+import { getKnownWalletName } from "@/lib/wallet-registry";
 import { AuctionStatsCharts } from "@/components/dashboard/AuctionStatsCharts";
 import { AccountSearch } from "@/components/dashboard/AccountSearch";
 import {
@@ -194,43 +195,53 @@ export default function Dashboard() {
     }));
   }, [data]);
 
-  // Resolve ENS names after data loads
+  // Resolve wallet names: known names sync, unknown via async ENS
   useEffect(() => {
     if (!data || data.topPayers.length === 0) return;
 
-    async function resolveNames() {
-      const addresses = data!.topPayers
-        .filter(p => p.fullAddress && !p.ensName)
-        .map(p => p.fullAddress);
+    // First pass: instantly apply known wallet-map names
+    const needsAsync: string[] = [];
+    const knownUpdates = new Map<string, string>();
 
-      if (addresses.length === 0) return;
-
-      setResolvingNames(true);
-      try {
-        const ensNames = await batchResolveENS(addresses);
-
-        // Update payers with resolved ENS names
-        setData(prevData => {
-          if (!prevData) return prevData;
-
-          const updatedPayers = prevData.topPayers.map(payer => {
-            const ensName = ensNames.get(payer.fullAddress?.toLowerCase());
-            if (ensName && !payer.ensName) {
-              return { ...payer, ensName };
-            }
-            return payer;
-          });
-
-          return { ...prevData, topPayers: updatedPayers };
-        });
-      } catch (err) {
-        console.error('Failed to resolve ENS names:', err);
-      } finally {
-        setResolvingNames(false);
+    for (const payer of data.topPayers) {
+      if (payer.ensName || !payer.fullAddress) continue;
+      const known = getKnownWalletName(payer.fullAddress);
+      if (known) {
+        knownUpdates.set(payer.fullAddress.toLowerCase(), known);
+      } else {
+        needsAsync.push(payer.fullAddress);
       }
     }
 
-    resolveNames();
+    // Apply known names immediately (no flash)
+    if (knownUpdates.size > 0) {
+      setData(prevData => {
+        if (!prevData) return prevData;
+        const updatedPayers = prevData.topPayers.map(payer => {
+          const name = knownUpdates.get(payer.fullAddress?.toLowerCase());
+          return name && !payer.ensName ? { ...payer, ensName: name } : payer;
+        });
+        return { ...prevData, topPayers: updatedPayers };
+      });
+    }
+
+    // Second pass: async ENS for unknown addresses only
+    if (needsAsync.length === 0) return;
+
+    setResolvingNames(true);
+    batchResolveENS(needsAsync)
+      .then(ensNames => {
+        setData(prevData => {
+          if (!prevData) return prevData;
+          const updatedPayers = prevData.topPayers.map(payer => {
+            const ensName = ensNames.get(payer.fullAddress?.toLowerCase());
+            return ensName && !payer.ensName ? { ...payer, ensName } : payer;
+          });
+          return { ...prevData, topPayers: updatedPayers };
+        });
+      })
+      .catch(err => console.error('Failed to resolve ENS names:', err))
+      .finally(() => setResolvingNames(false));
   }, [data?.topPayers.length]);
 
   // Show loading state

--- a/app/payee-accounts/page.tsx
+++ b/app/payee-accounts/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { PayeeDisplay, fetchAllPayees, fetchAccountDetail, AccountDetail, formatDataSize, formatCurrency, RailDisplay } from "@/lib/graphql/fetchers";
 import { batchResolveENS } from "@/lib/ens";
+import { getKnownWalletName } from "@/lib/wallet-registry";
 import { useEnsName } from "@/lib/hooks/useEnsResolution";
 import { useSPRegistry } from "@/lib/sp-registry/hooks";
 import { SPHero } from "@/components/sp-registry";
@@ -189,7 +190,12 @@ function PayeeDetailView({ address }: { address: string }) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-purple-900">Payee Details</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold text-purple-900">Payee Details</h1>
+            {resolvingName && (
+              <span className="text-sm text-gray-400 animate-pulse">· Resolving names…</span>
+            )}
+          </div>
           <div className="flex items-center gap-2 mt-1">
             {ensName ? (
               <>
@@ -390,38 +396,46 @@ function PayeeListView() {
     loadData();
   }, []);
 
-  // Resolve ENS names after data loads
+  // Resolve wallet names: known names sync, unknown via async ENS
   useEffect(() => {
     if (payees.length === 0) return;
 
-    async function resolveNames() {
-      const addresses = payees
-        .filter((p) => p.fullAddress && !p.ensName)
-        .map((p) => p.fullAddress);
+    const needsAsync: string[] = [];
+    const knownUpdates = new Map<string, string>();
 
-      if (addresses.length === 0) return;
-
-      setResolvingNames(true);
-      try {
-        const ensNames = await batchResolveENS(addresses);
-
-        setPayees((prevPayees) =>
-          prevPayees.map((payee) => {
-            const ensName = ensNames.get(payee.fullAddress?.toLowerCase());
-            if (ensName && !payee.ensName) {
-              return { ...payee, ensName };
-            }
-            return payee;
-          })
-        );
-      } catch (err) {
-        console.error("Failed to resolve ENS names:", err);
-      } finally {
-        setResolvingNames(false);
+    for (const payee of payees) {
+      if (payee.ensName || !payee.fullAddress) continue;
+      const known = getKnownWalletName(payee.fullAddress);
+      if (known) {
+        knownUpdates.set(payee.fullAddress.toLowerCase(), known);
+      } else {
+        needsAsync.push(payee.fullAddress);
       }
     }
 
-    resolveNames();
+    if (knownUpdates.size > 0) {
+      setPayees((prev) =>
+        prev.map((p) => {
+          const name = knownUpdates.get(p.fullAddress?.toLowerCase());
+          return name && !p.ensName ? { ...p, ensName: name } : p;
+        })
+      );
+    }
+
+    if (needsAsync.length === 0) return;
+
+    setResolvingNames(true);
+    batchResolveENS(needsAsync)
+      .then((ensNames) => {
+        setPayees((prev) =>
+          prev.map((p) => {
+            const name = ensNames.get(p.fullAddress?.toLowerCase());
+            return name && !p.ensName ? { ...p, ensName: name } : p;
+          })
+        );
+      })
+      .catch((err) => console.error("Failed to resolve ENS names:", err))
+      .finally(() => setResolvingNames(false));
   }, [payees.length]);
 
   // Calculate hero metrics

--- a/app/payer-accounts/page.tsx
+++ b/app/payer-accounts/page.tsx
@@ -25,6 +25,7 @@ import {
   NETWORK,
 } from "@/lib/graphql/client";
 import { batchResolveENS } from "@/lib/ens";
+import { getKnownWalletName } from "@/lib/wallet-registry";
 import { useEnsName } from "@/lib/hooks/useEnsResolution";
 import {
   calculateDataSetsSummary,
@@ -401,7 +402,12 @@ function PayerDetailView({ address }: { address: string }) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">Payer Details</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold">Payer Details</h1>
+            {resolvingName && (
+              <span className="text-sm text-gray-400 animate-pulse">· Resolving names…</span>
+            )}
+          </div>
           <div className="flex items-center gap-2 mt-1">
             {ensName ? (
               <>
@@ -829,38 +835,46 @@ function PayerListView() {
     loadData();
   }, []);
 
-  // Resolve ENS names after data loads
+  // Resolve wallet names: known names sync, unknown via async ENS
   useEffect(() => {
     if (payers.length === 0) return;
 
-    async function resolveNames() {
-      const addresses = payers
-        .filter((p) => p.fullAddress && !p.ensName)
-        .map((p) => p.fullAddress);
+    const needsAsync: string[] = [];
+    const knownUpdates = new Map<string, string>();
 
-      if (addresses.length === 0) return;
-
-      setResolvingNames(true);
-      try {
-        const ensNames = await batchResolveENS(addresses);
-
-        setPayers((prevPayers) =>
-          prevPayers.map((payer) => {
-            const ensName = ensNames.get(payer.fullAddress?.toLowerCase());
-            if (ensName && !payer.ensName) {
-              return { ...payer, ensName };
-            }
-            return payer;
-          })
-        );
-      } catch (err) {
-        console.error("Failed to resolve ENS names:", err);
-      } finally {
-        setResolvingNames(false);
+    for (const payer of payers) {
+      if (payer.ensName || !payer.fullAddress) continue;
+      const known = getKnownWalletName(payer.fullAddress);
+      if (known) {
+        knownUpdates.set(payer.fullAddress.toLowerCase(), known);
+      } else {
+        needsAsync.push(payer.fullAddress);
       }
     }
 
-    resolveNames();
+    if (knownUpdates.size > 0) {
+      setPayers((prev) =>
+        prev.map((p) => {
+          const name = knownUpdates.get(p.fullAddress?.toLowerCase());
+          return name && !p.ensName ? { ...p, ensName: name } : p;
+        })
+      );
+    }
+
+    if (needsAsync.length === 0) return;
+
+    setResolvingNames(true);
+    batchResolveENS(needsAsync)
+      .then((ensNames) => {
+        setPayers((prev) =>
+          prev.map((p) => {
+            const name = ensNames.get(p.fullAddress?.toLowerCase());
+            return name && !p.ensName ? { ...p, ensName: name } : p;
+          })
+        );
+      })
+      .catch((err) => console.error("Failed to resolve ENS names:", err))
+      .finally(() => setResolvingNames(false));
   }, [payers.length]);
 
   // Prepare chart data with cumulative values (total at each point in time)

--- a/lib/hooks/useEnsResolution.ts
+++ b/lib/hooks/useEnsResolution.ts
@@ -1,16 +1,22 @@
 import { useState, useEffect } from "react";
 import { resolveENS } from "@/lib/ens";
+import { getKnownWalletName } from "@/lib/wallet-registry";
 
 /**
  * Resolve a single address to its ENS/wallet-map name.
- * Returns the resolved name and whether resolution is in progress.
+ * Wallet-map names resolve synchronously (no flash).
+ * Only unknown addresses trigger async ENS resolution.
  */
 export function useEnsName(address: string | null | undefined) {
-  const [ensName, setEnsName] = useState<string | null>(null);
-  const [resolving, setResolving] = useState(false);
+  // Check wallet registry synchronously — instant for known addresses
+  const knownName = address ? getKnownWalletName(address) : undefined;
+
+  const [ensName, setEnsName] = useState<string | null>(knownName ?? null);
+  const [resolving, setResolving] = useState(!knownName && !!address);
 
   useEffect(() => {
-    if (!address) return;
+    // Skip async resolution if already resolved from wallet registry
+    if (!address || knownName) return;
 
     setResolving(true);
     resolveENS(address)
@@ -19,7 +25,7 @@ export function useEnsName(address: string | null | undefined) {
       })
       .catch((err) => console.error("Failed to resolve ENS:", err))
       .finally(() => setResolving(false));
-  }, [address]);
+  }, [address, knownName]);
 
-  return { ensName, resolving };
+  return { ensName: ensName ?? knownName ?? null, resolving };
 }


### PR DESCRIPTION
## Summary

Addresses now pulse with a subtle `animate-pulse` animation while ENS/wallet-map names are being resolved. Once the name resolves, it replaces the address cleanly. If no name is found, the animation stops and the plain address remains.

## Implementation

- **Dashboard** (`app/page.tsx`): tracks `resolvingNames` state, passes to `TopPayersTable`
- **TopPayersTable**: accepts `resolvingNames` prop, applies `animate-pulse` to unresolved address text
- **Payer detail** (`app/payer-accounts/page.tsx`): tracks `resolvingName` for header address
- **Payer list** (`app/payer-accounts/page.tsx`): tracks `resolvingNames` for table addresses
- **Payee detail** (`app/payee-accounts/page.tsx`): tracks `resolvingName` for header address
- **Payee list** (`app/payee-accounts/page.tsx`): tracks `resolvingNames` for table addresses

Uses Tailwind's built-in `animate-pulse` — no custom CSS needed.

## Test Plan

- [ ] Vercel preview deployment works
- [ ] On dashboard, unresolved addresses pulse briefly then show names
- [ ] On payer detail, address pulses then resolves to name
- [ ] On payee detail, address pulses then resolves to name
- [ ] Addresses without names stop pulsing and show plain address

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Indicate ENS name resolution progress by animating wallet addresses across dashboard, payer, and payee views.

New Features:
- Show a pulsing animation on dashboard top payer addresses while their ENS names are being resolved.
- Show a pulsing animation on payer detail header addresses while their ENS names are being resolved.
- Show a pulsing animation on payer list addresses while their ENS names are being batch-resolved.
- Show a pulsing animation on payee detail header addresses while their ENS names are being resolved.
- Show a pulsing animation on payee list addresses while their ENS names are being batch-resolved.

Enhancements:
- Stop the pulsing animation once ENS name resolution completes or fails, leaving the plain address when no name is found.