### PR TITLE
Add Total Settled card to payer detail metrics

### DIFF
--- a/app/payer-accounts/page.tsx
+++ b/app/payer-accounts/page.tsx
@@ -453,7 +453,7 @@ function PayerDetailView({ address }: { address: string }) {
       </div>
 
       {/* Summary Cards */}
-      <div className="grid grid-cols-5 gap-4">
+      <div className="grid grid-cols-6 gap-4">
         <div className="bg-white border rounded-lg p-4">
           <p className="text-sm text-gray-500 flex items-center gap-1">
             Available Funds
@@ -477,6 +477,18 @@ function PayerDetailView({ address }: { address: string }) {
             </span>
           </p>
           <p className="text-2xl font-bold">{account.totalLocked}</p>
+        </div>
+        <div className="bg-white border rounded-lg p-4">
+          <p className="text-sm text-gray-500 flex items-center gap-1">
+            Total Settled
+            <span
+              className="text-gray-400 cursor-help"
+              title="Total amount settled to service providers across all payment rails."
+            >
+              ⓘ
+            </span>
+          </p>
+          <p className="text-2xl font-bold">{account.totalSettled}</p>
         </div>
         <div className="bg-white border rounded-lg p-4">
           <p className="text-sm text-gray-500">Total Storage</p>


### PR DESCRIPTION
## Summary

- Adds a "Total Settled" hero metric card to the payer detail page, positioned after Locked Funds
- Grid changes from 5 to 6 columns to accommodate the new card
- Data was already computed by `fetchAccountDetail()` (`account.totalSettled`) but not displayed

## Test Plan

- [ ] Vercel preview deployment loads payer detail page
- [ ] "Total Settled" card appears after "Locked Funds"
- [ ] Value matches sum of settled amounts shown in individual rails

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new payer detail summary metric card for total settled funds and adjust the layout to fit it.

New Features:
- Display a Total Settled summary card on the payer detail page using existing account.totalSettled data.

Enhancements:
- Expand the payer detail summary grid from five to six columns to accommodate the additional metric card.